### PR TITLE
fix: method_cache remove __set_name__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 <!--
-IMPORTANT: the build script extracts the most recent versino from this file
+IMPORTANT: the build script extracts the most recent version from this file
 so make sure you follow the template
 -->
 
@@ -26,6 +26,11 @@ so make sure you follow the template
 
 -->
 
+## 1.0.dev 2021-02-19
+
+### Fixed
+
+* Fix `method_cache` to not set `name` on parent class which would break classes that had an attribute `name`
 
 ## 1.0.0-rc2 2020-09-14
 

--- a/allianceutils/decorators.py
+++ b/allianceutils/decorators.py
@@ -14,15 +14,13 @@ class _CachedMethodDescriptor:
     def __get__(self, obj, objtype):
         f = functools.partial(self.__call__, obj)
         f.clear_cache = functools.partial(self.clear_cache, obj)
+        functools.update_wrapper(f, self.fn)
         return f
 
     def __call__(self, obj, *args, **kwargs):
         if not hasattr(obj, self.cache_attr):
             setattr(obj, self.cache_attr, self.fn(obj, *args, **kwargs))
         return getattr(obj, self.cache_attr)
-
-    def __set_name__(self, cls, name):
-        cls.name = name
 
     def clear_cache(self, obj):
         try:
@@ -40,7 +38,7 @@ def method_cache(fn: Callable) -> Callable:
 
     Only works on methods with no parameters (other than self)
 
-    Clear cache for MyObject.my_method with my_object.clear_cache()
+    Clear cache for MyObject.my_method with my_object.my_method.clear_cache()
     """
     if isinstance(fn, (staticmethod, classmethod)):
         # if staticmethod or classmethod then inspect.signature() fails even trying to introspect the function

--- a/test_allianceutils/tests/test_decorators.py
+++ b/test_allianceutils/tests/test_decorators.py
@@ -26,6 +26,8 @@ class DecoratorsTest(SimpleTestCase):
         obj.my_method.clear_cache()
         self.assertEqual(obj.my_method(), 3)
 
+        self.assertEqual(obj.my_method.__name__, 'my_method')
+
         with self.assertRaises(AttributeError):
             # Trying to clear the class method doesn't work (we'd have
             # to keep track of every single MyClass instance to do this)


### PR DESCRIPTION
- Remove `__set_name__` which was incorrectly adding a name property to the owner
- Call update_wrapper so method retains `__name__` and `__doc__`
- Fix incorrect header comment