### PR TITLE
fix: CamelCaseMultiPartJSONParser.parse failure

### DIFF
--- a/allianceutils/api/parsers.py
+++ b/allianceutils/api/parsers.py
@@ -122,4 +122,4 @@ class CamelCaseMultiPartJSONParser(MultiPartParser):
                 data_and_files.data.get("jsonData"), object_pairs_hook=hook
             )
             return self.underscoreize(json_data)
-        return super().parse(stream, media_type, parser_context)
+        return data_and_files


### PR DESCRIPTION
Resolve bug where if the HTTP_X_MULTIPART_JSON header is not set it tries to parse the stream a second time, which returns no data (it’s already parsed it on entry to the method)