### PR TITLE
fix: is_static_expression handle filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ so make sure you follow the template
 
 -->
 
+## 4.x.x unreleased
+
+### Fixed
+
+* `is_static_expression` now handles expressions with filters correctly
+
 ## 4.0.0 2024-03-18
 
 ### Breaking Changes

--- a/src/test_allianceutils/tests/test_template_utils.py
+++ b/src/test_allianceutils/tests/test_template_utils.py
@@ -1,0 +1,33 @@
+from typing import cast
+
+from django.template.base import Template
+from django.test import SimpleTestCase
+
+from allianceutils.template import is_static_expression
+from allianceutils.templatetags.default_value import DefaultValueNode
+
+
+class TestTemplateUtils(SimpleTestCase):
+
+    def _get_as_var(self, contents: str):
+        # Bit hacky, but use the default_value tag to parse the variable, which when then access from
+        # ``DefaultValueNode.assignments``.
+        template = Template(f'{{% load default_value %}}{{% default_value test_var={contents}  %}}')
+        node: DefaultValueNode = cast(DefaultValueNode, template.compile_nodelist()[-1])
+        return node.assignments['test_var']
+
+    def test_is_static_expression_string(self):
+        self.assertTrue(is_static_expression(self._get_as_var('"foo"')))
+
+    def test_is_static_expression_bool(self):
+        self.assertTrue(is_static_expression(self._get_as_var("True")))
+        self.assertTrue(is_static_expression(self._get_as_var("False")))
+
+    def test_is_static_expression_with_filter(self):
+        self.assertFalse(is_static_expression(self._get_as_var("foo|add:''")))
+
+    def test_is_static_expression_raw_string(self):
+        self.assertTrue(is_static_expression("foo"))
+
+    def test_is_static_expression_other_value(self):
+        self.assertFalse(is_static_expression({}))  # type: ignore[arg-type] # just testing runtime behaviour


### PR DESCRIPTION
Prior to this fix this was considered static: {% my_tag url="my-url"|url_with_perm:obj.pk %}. Now, any filter in the expression will result in it being considered not-static.