### PR TITLE
Fix/querycount middleware drf compat

### DIFF
--- a/src/allianceutils/middleware/query_count.py
+++ b/src/allianceutils/middleware/query_count.py
@@ -1,8 +1,3 @@
-"""
-Django DB instrumentation makes this relatively simple now:
-
-https://docs.djangoproject.com/en/dev/topics/db/instrumentation/
-"""
 from __future__ import annotations
 
 import logging
@@ -69,8 +64,12 @@ class QueryCountMiddleware:
 
     @classmethod
     def set_threshold(cls, request: HttpRequest, threshold: int):
-        cast(QueryCountHttpRequest, request).QUERY_COUNT_WARNING_THRESHOLD = threshold
+        # Use underlying Django request if available (e.g., DRF Request)
+        target_request = getattr(request, '_request', request)
+        cast(QueryCountHttpRequest, target_request).QUERY_COUNT_WARNING_THRESHOLD = threshold
 
     @classmethod
     def increase_threshold(cls, request: HttpRequest, increment: int):
-        cast(QueryCountHttpRequest, request).QUERY_COUNT_WARNING_THRESHOLD += increment
+        # Use underlying Django request if available (e.g., DRF Request)
+        target_request = getattr(request, '_request', request)
+        cast(QueryCountHttpRequest, target_request).QUERY_COUNT_WARNING_THRESHOLD += increment

--- a/src/allianceutils/middleware/query_count.py
+++ b/src/allianceutils/middleware/query_count.py
@@ -1,3 +1,8 @@
+"""
+Django DB instrumentation makes this relatively simple now:
+
+https://docs.djangoproject.com/en/dev/topics/db/instrumentation/
+"""
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
This PR fixes [Issue #37](https://github.com/AllianceSoftware/django-allianceutils/issues/37#issue-3190669018), where QueryCountMiddleware.set_threshold() and increase_threshold() fail when called with a DRF Request object instead of Django’s HttpRequest.